### PR TITLE
Change package name to cc.getportal.portal

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
     "ios": {
       "supportsTablet": true,
       "userInterfaceStyle": "dark",
-      "bundleIdentifier": "com.portaltechnologiesinc.portal",
+      "bundleIdentifier": "cc.getportal.portal",
       "associatedDomains": [
         "applinks:portal.app"
       ]
@@ -29,7 +29,7 @@
         "foregroundImage": "./assets/images/appLogo.png",
         "backgroundColor": "#000000"
       },
-      "package": "com.portaltechnologiesinc.portal",
+      "package": "cc.getportal.portal",
       "userInterfaceStyle": "dark",
       "intentFilters": [
         {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "portal",
+  "name": "cc.getportal.portal",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "type": "module",


### PR DESCRIPTION
This PR changes the package name from 'com.portaltechnologiesinc.portal' to 'cc.getportal.portal' as requested in issue #39.

Changes made:
- Updated iOS bundleIdentifier in app.json
- Updated Android package name in app.json  
- Updated package name in package.json

Fixes #39