### PR TITLE
Fix ecash error when redeeming a token

### DIFF
--- a/context/ECashContext.tsx
+++ b/context/ECashContext.tsx
@@ -88,6 +88,14 @@ export function ECashProvider({ children, mnemonic }: { children: ReactNode; mne
     const storage = new CashuStorage(DB);
     const wallet = await CashuWallet.create(mintUrl, unit, seed, storage);
 
+    // This connects to the mint and makes sure the wallet is up to date
+    // We run this only if we don't have any proofs for this (mint_url, unit) pair yet
+    const isPairPresent = (await DB.getMintUnitPairs()).filter(pair => pair[0] === mintUrl && pair[1] === unit).length > 0;
+    if (!isPairPresent) {
+      console.log(`Restoring proofs for ${mintUrl}-${unit}`);
+      await wallet.restoreProofs();
+    }
+
     try {
       setWallets(prev => {
         const newMap = { ...prev };


### PR DESCRIPTION
Fixes the "blinded message already signed" error which would happen when CDK was trying to get an already expired secret re-signed by the mint.

By "restoring" the proofs we get back in sync with the mint and we know which secrets have been spent. We assume the same key is not being used anywhere else, so we only run the restore when we don't have any proofs stored locally for a given (mint_url, unit) pair.