### PR TITLE
Fix race condition when redeeming an ecash token

### DIFF
--- a/context/NostrServiceContext.tsx
+++ b/context/NostrServiceContext.tsx
@@ -394,23 +394,20 @@ export const NostrServiceProvider: React.FC<NostrServiceProviderProps> = ({
                 const token = event.inner.token;
 
                 // Check if we've already processed this token
-                const isProcessed = await DB.isCashuTokenProcessed(token);
-                if (isProcessed) {
-                  console.log('Cashu token already processed, skipping');
-                  return;
-                }
-
                 const tokenInfo = await parseCashuToken(token);
-                const wallet = await eCashContext.addWallet(tokenInfo.mintUrl, tokenInfo.unit);
-                await wallet.receiveToken(token);
-
-                // Mark token as processed after successful processing
-                await DB.markCashuTokenAsProcessed(
+                const isProcessed = await DB.markCashuTokenAsProcessed(
                   token,
                   tokenInfo.mintUrl,
                   tokenInfo.unit,
                   tokenInfo.amount ? Number(tokenInfo.amount) : 0
                 );
+                if (isProcessed) {
+                  console.log('Cashu token already processed, skipping');
+                  return;
+                }
+
+                const wallet = await eCashContext.addWallet(tokenInfo.mintUrl, tokenInfo.unit);
+                await wallet.receiveToken(token);
 
                 console.log('Cashu token processed successfully');
 

--- a/services/database/DatabaseProvider.tsx
+++ b/services/database/DatabaseProvider.tsx
@@ -370,12 +370,19 @@ export const DatabaseProvider = ({ children }: DatabaseProviderProps) => {
       }
 
       if (currentDbVersion <= 10) {
-        // The processed_cashu_tokens table is now created dynamically when needed
-        // This prevents migration issues and allows for better error handling
+        await db.execAsync(`
+          CREATE TABLE IF NOT EXISTS processed_cashu_tokens (
+            token_hash TEXT PRIMARY KEY NOT NULL,
+            mint_url TEXT NOT NULL,
+            unit TEXT NOT NULL,
+            amount INTEGER NOT NULL,
+            processed_at INTEGER NOT NULL -- Unix timestamp
+          );
+          CREATE INDEX IF NOT EXISTS idx_processed_cashu_tokens_hash ON processed_cashu_tokens(token_hash);
+          CREATE INDEX IF NOT EXISTS idx_processed_cashu_tokens_mint ON processed_cashu_tokens(mint_url);
+        `);
         currentDbVersion = 11;
-        console.log(
-          'Updated to version 11 - processed_cashu_tokens table will be created dynamically'
-        );
+        console.log('Created processed_cashu_tokens table - now at version 11');
       }
 
       await db.execAsync(`PRAGMA user_version = ${DATABASE_VERSION}`);


### PR DESCRIPTION
There was a TOC-TOU issue with the deduplication of ecash tokens, because we whould check first, then redeem (which takes a long time because the library needs to connect to the mint) and then mark as processed.

This meant that we could still accidentally process the same token multiple times, causing the "blinded message already signed".

This fixes the issue by atomically checking/marking the token as processed. Plus it simplifies the migration logic which was incredibly complex for no reason. We have a way to do migrations, we should just use it rather than running migrations randomly inside of other actions.