### PR TITLE
(fix) : amount cut fix

### DIFF
--- a/components/ActivityDetail/ActivityMainCard.tsx
+++ b/components/ActivityDetail/ActivityMainCard.tsx
@@ -160,10 +160,10 @@ const styles = StyleSheet.create({
   amount: {
     fontSize: 32,
     fontWeight: '700',
+    paddingVertical: 12,
   },
   amountSubtext: {
     fontSize: 16,
-    marginTop: 4,
   },
   description: {
     fontSize: 16,


### PR DESCRIPTION
I solved this simple UI issue, primarily the cause was the fontSize onthe  amount style, which I solved with a simple PaddingVertical. marginTop of the subtext was also removed to avoid a lot of gap between them after the padding

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-04 at 13 05 03" src="https://github.com/user-attachments/assets/3949f39a-ae4a-4d9c-982c-3c893c06780e" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-04 at 13 05 06" src="https://github.com/user-attachments/assets/0eb46491-1dc2-45ad-b5fd
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-04 at 13 09 32" src="https://github.com/user-attachments/assets/2aae0a97-776b-4e38-987c-7ae4a590247b" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-04 at 13 09 39" src="https://github.com/user-attachments/assets/5a8d7ad9-9390-4e64-9aed-e6391f1d39f1" />
-0f28d03de6ce" />
