### PR TITLE
Fix profile operations and relay management

### DIFF
--- a/app/relays.tsx
+++ b/app/relays.tsx
@@ -17,6 +17,7 @@ import { useThemeColor } from '@/hooks/useThemeColor';
 
 import popularRelayListFile from '../assets/RelayList.json';
 import { useNostrService } from '@/context/NostrServiceContext';
+import { PortalAppManager } from '@/services/PortalAppManager';
 
 function isWebsocketUri(uri: string): boolean {
   const regex = /^wss?:\/\/([a-zA-Z0-9.-]+)(:\d+)?(\/[^\s]*)?$/;
@@ -124,7 +125,7 @@ export default function NostrRelayManagementScreen() {
         // Mark relay as removed in the context to prevent it from showing in connection status
         nostrService.markRelayAsRemoved(oldRelay);
 
-        const promise = nostrService.portalApp?.removeRelay(oldRelay);
+        const promise = PortalAppManager.tryGetInstance().removeRelay(oldRelay);
         if (promise) {
           removePromises.push(
             promise.catch(error => {
@@ -142,7 +143,7 @@ export default function NostrRelayManagementScreen() {
         // Clear from removed list and add to native layer
         nostrService.clearRemovedRelay(newRelay);
 
-        const promise = nostrService.portalApp?.addRelay(newRelay);
+        const promise = PortalAppManager.tryGetInstance().addRelay(newRelay);
         if (promise) {
           addPromises.push(
             promise.catch(error => {


### PR DESCRIPTION
## Problem
Profile set and fetch operations were broken after \`portalApp\` was removed from NostrServiceContext in recent commits. This caused:
- Profile fetching to fail
- Profile setting to fail  
- Relay add/remove operations to fail
- Auto-profile loading on app startup to fail

## Solution
Replaced all \`nostrService.portalApp\` references with \`PortalAppManager.tryGetInstance()\` to follow the established singleton pattern.

## Changes
- **UserProfileContext.tsx**: Fixed fetchProfile, setProfile, and auto-fetch logic
- **relays.tsx**: Fixed addRelay and removeRelay operations
- Added PortalAppManager imports where needed

## Testing
- ✅ No linting errors
- ✅ All portalApp references removed
- ✅ Profile operations restored
- ✅ Relay management restored

Fixes #116