### PR TITLE
Support noRequest URLs

### DIFF
--- a/context/PendingRequestsContext.tsx
+++ b/context/PendingRequestsContext.tsx
@@ -782,6 +782,10 @@ export const PendingRequestsProvider: React.FC<{ children: ReactNode }> = ({ chi
   // Show skeleton loader and set timeout for request
   const showSkeletonLoader = useCallback(
     (parsedUrl: KeyHandshakeUrl) => {
+      if (parsedUrl.noRequest) {
+        return;
+      }
+
       // Clean up any existing timeout
       if (timeoutId) {
         clearTimeout(timeoutId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "expo-web-browser": "~14.2.0",
         "lucide-react-native": "~0.516.0",
         "nostr-tools": "~2.12.0",
-        "portal-app-lib": "^0.4.5",
+        "portal-app-lib": "^0.4.7",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-icons": "~5.5.0",
@@ -13969,9 +13969,9 @@
       }
     },
     "node_modules/portal-app-lib": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/portal-app-lib/-/portal-app-lib-0.4.5.tgz",
-      "integrity": "sha512-DhVrBD61TVLuMKXK/TLuAzoen+Fiv73bpywvwA4uo20bzZ1riPA+2pMHS0zOMS57Ff+4zz5osYDOP4rzxfP+VA==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/portal-app-lib/-/portal-app-lib-0.4.7.tgz",
+      "integrity": "sha512-H4Z8NHLT7yOwrz79iaNtTReFB8O6RI5XE0L81aJy+hM6pPnLQcvzK8VPbH+ELjcl1P8cIvkFlkm4dHCmus12Yw==",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "expo-web-browser": "~14.2.0",
     "lucide-react-native": "~0.516.0",
     "nostr-tools": "~2.12.0",
-    "portal-app-lib": "^0.4.5",
+    "portal-app-lib": "^0.4.7",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-icons": "~5.5.0",


### PR DESCRIPTION
Key handshake urls can signal a request shouldn't be expected with `no_request=true`.

Suppress the skeleton in those cases.

Fixes #132