### PR TITLE
fix(webview): disable cache on verification WebViews to prevent stale frontend

### DIFF
--- a/app/(onboarding)/age-verification.tsx
+++ b/app/(onboarding)/age-verification.tsx
@@ -272,6 +272,10 @@ export default function AgeVerification() {
                   mediaPlaybackRequiresUserAction={false}
                   // Android specific
                   mixedContentMode="always"
+                  // Disable cache to prevent stale frontend versions from breaking
+                  // the WebSocket/attestation connection after server updates
+                  cacheEnabled={false}
+                  incognito={true}
                   onHttpError={syntheticEvent => {
                     const { nativeEvent } = syntheticEvent;
                     console.error('[AgeVerification] WebView HTTP error:', {

--- a/app/passport-nfc-scan/index.tsx
+++ b/app/passport-nfc-scan/index.tsx
@@ -540,6 +540,8 @@ export default function PassportNfcScanScreen() {
             showsVerticalScrollIndicator={false}
             bounces={false}
             mixedContentMode="always"
+            cacheEnabled={false}
+            incognito={true}
           />
           {isVerifyLoading && (
             <View style={[StyleSheet.absoluteFillObject, { justifyContent: 'center' }]}>


### PR DESCRIPTION
## Problem

After server-side updates to `verify.getportal.cc`, the WebView in the app could serve a cached version of the frontend. The cached frontend's WebSocket/attestation handshake is incompatible with the updated backend, causing **"Could not connect to the verification server"** errors.

Users had to reinstall the app to clear the WebView cache — not acceptable UX.

## Fix

Set `cacheEnabled={false}` and `incognito={true}` on both verification WebViews:

- `app/passport-nfc-scan/index.tsx` — NFC passport verification flow
- `app/(onboarding)/age-verification.tsx` — face verification flow

Every verification session now loads the latest frontend directly from the server, preventing cache staleness after backend deploys.

## Why `incognito={true}`?

On iOS, `cacheEnabled={false}` alone may not fully prevent all caching (WKWebView has its own cache layers). `incognito={true}` ensures the WebView uses a non-persistent data store — no cookies, cache, or local storage carry over between sessions.